### PR TITLE
Heartbeat random interval

### DIFF
--- a/server/AsieLauncher/internal/also-heartbeat.js
+++ b/server/AsieLauncher/internal/also-heartbeat.js
@@ -57,7 +57,10 @@ exports.create = function(config, serverInfo) {
 			sendHeartbeat(generateHeartbeat(config));
 		}
 		sendHeartbeat(initialHeartbeat, "/init", function(){
-			var interval = setInterval(hbFunc, 90*1000); // Every 90 seconds should be enough.
+                        // To avoid serverlist overload, heartbeat interval 
+                        // set to a random number between 60 and 180 seconds 
+                        var randomDelay = Math.floor(Math.random()*(180-60)+60);
+			var interval = setInterval(hbFunc, randomDelay*1000);
 			hbFunc();
 		});
 	}


### PR DESCRIPTION
Changing the heartbeat from every 90 seconds to a random value between 60 and 180 seconds. This will help keep the serverlist from being overwhelmed by servers sending their heartbeat all at once.
